### PR TITLE
✨ Feat: add middleware for route authentication

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,27 @@
+import { NextRequest } from "next/server";
+import { withoutAuth } from "./middlewares/withoutAuth";
+import { withAuth } from "./middlewares/withAuth";
+
+export function middleware(request: NextRequest) {
+  const onlyNotLoggedInPaths = ["/login", "/sign-up"];
+  const onlyLoggedInPaths = ["/my-page", "/my-page/mentor"];
+
+  if (onlyNotLoggedInPaths.includes(request.nextUrl.pathname)) {
+    return withoutAuth(request);
+  }
+
+  if (onlyLoggedInPaths.includes(request.nextUrl.pathname)) {
+    return withAuth(request);
+  }
+}
+
+export const config = {
+  matcher: [
+    "/login",
+    "/sign-up",
+    "courses",
+    "/courses/:courseId",
+    "/my-page",
+    "/my-page/mentor",
+  ],
+};

--- a/middlewares/withAuth.ts
+++ b/middlewares/withAuth.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// The user who has JWT can access this page.
+export async function withAuth(req: NextRequest) {
+  const redirectUrl = new URL("/login", req.url);
+
+  const token = req.cookies.get(`${process.env.JWT_NAME}`)!.value;
+
+  if (!token) {
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  try {
+    const response = await fetch(`${process.env.DOMAIN_URL}/api/auth`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        token: token,
+      }),
+    });
+
+    const res = await response.json();
+
+    if (!res) {
+      return NextResponse.redirect(redirectUrl);
+    }
+  } catch (e) {
+    console.log(e);
+
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  return NextResponse.next();
+}

--- a/middlewares/withoutAuth.ts
+++ b/middlewares/withoutAuth.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// The user only who does not logged in can access this page.
+export async function withoutAuth(req: NextRequest) {
+  // Default redirect URL
+  const redirectUrl = new URL("/", req.url);
+
+  const token = req.cookies.get(`${process.env.JWT_NAME}`)?.value;
+
+  // If the user doesn't have a JWT, the user can use this page.
+  if (!token) {
+    return NextResponse.next();
+  }
+
+  return NextResponse.redirect(redirectUrl);
+}


### PR DESCRIPTION
Route authentication!

For now, we have the routes below.

- `/login`
- `/sign-up`
- `courses`
- `/courses/:courseId`
- `/my-page`
- `/my-page/mentor`

Anyone can access: `courses`, `/courses/:courseId`
Only not logged in user can access: `/login`, `/sign-up`
Only logged in user can access: `/my-page`, `/my-page/mentor`

If the user has JWT, they can access `Only logged in user can access` pages.
On the other hand, if the user doesn't have JWT, they can access `Anyone can access` & `Only not logged in user can access` pages.